### PR TITLE
fix: crash when converting invalid JSON object on Swift SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.2
 
-* fix: crash when converting invalid JSON object for Swift SDK
+* fix: crash when converting invalid JSON object on Swift SDK
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.2
+
+* fix: crash when converting invalid JSON object for Swift SDK
+
+## 0.4.1
+
+* fix: the issue when initialize SDK without global attribute
+
 ## 0.4.0
 
 * feat: add preset traffic source attributes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
-        implementation 'software.aws.solution:clickstream:0.12.0'
+        implementation 'software.aws.solution:clickstream:0.13.0'
         implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.10"))
     }
 


### PR DESCRIPTION
## Description
1. fix crash when converting invalid JSON object on Swift SDK

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
